### PR TITLE
V-73237: s/Tmp/Tpm/g

### DIFF
--- a/controls/V-73237.rb
+++ b/controls/V-73237.rb
@@ -49,13 +49,13 @@ control 'V-73237' do
 
   if is_domain != 'WORKGROUP'
     tpm_ready = command('Get-Tpm | select -expand TpmReady').stdout.strip
-    tmp_present = command('Get-Tpm | select -expand TpmPresent').stdout.strip
-    describe 'Trusted Platform Module (TPM) TmpReady' do
+    tpm_present = command('Get-Tpm | select -expand TpmPresent').stdout.strip
+    describe 'Trusted Platform Module (TPM) TpmReady' do
       subject { tpm_ready }
       it { should eq 'True' }
     end
-    describe 'Trusted Platform Module (TPM) TmpPresent' do
-      subject { tmp_present }
+    describe 'Trusted Platform Module (TPM) TpmPresent' do
+      subject { tpm_present }
       it { should eq 'True' }
     end
   end


### PR DESCRIPTION
The variables and messages in V-73237 refer to a TPM (Trusted
Platform Module). Unfortunately some typos snuck into the code
though and so some variables and strings refer to "tmp" instead.

This patch changes all variables and strings to mention TPM.

Signed-off-by: Alexander Graf <agraf@csgraf.de>