### PR TITLE
V-73221 Fixed newline issue

### DIFF
--- a/controls/V-73221.rb
+++ b/controls/V-73221.rb
@@ -76,7 +76,8 @@ control 'V-73221' do
   administrators = attribute('administrators')
   is_AD_only_system = input('is_AD_only_system')
   domain_role = command('wmic computersystem get domainrole | Findstr /v DomainRole').stdout.strip
-  administrator_group = command("net localgroup Administrators | Format-List | Findstr /V 'Alias Name Comment Members - command'").stdout.strip.split('\n')
+  administrator_group = command("Get-LocalGroupMember -Group \"Administrators\" | select -ExpandProperty Name | ForEach-Object {$_ -replace \"$env:COMPUTERNAME\\\\\" -replace \"\"}").stdout.strip.split("\r\n")
+
 
   if (domain_role == '2' || domain_role == '3') && !is_AD_only_system
     administrator_group.each do |user|


### PR DESCRIPTION
The existing code in V-73221.rb leads to a false positive for some values in the 'administrators' input in inspec.yml. 

After adding a local non-domain user with just the username (e.g. 'someUserName') to the 'administators' input array in inspec.yml, the command() in

administrator_group = command("net localgroup Administrators | Format-List | Findstr /V 'Alias Name Comment Members - command'").stdout.strip.split('\n')

found at https://github.com/mitre/microsoft-windows-server-2016-stig-baseline/blob/f39df73f0a993464de5c6a05bfc673ad3e4a5266/controls/V-73221.rb#L79 leads to the inclusion of a newline in the result that the code cannot accurately parse, e.g. 

> net localgroup Administrators | Format-List | Find str /V 'Alias Name Comment Members - command'
#Output includes newline
someDomainName\Domain Admins
someUserName

and this leads to a false test result.

Using the 2019 profile code (https://github.com/mitre/microsoft-windows-server-2019-stig-baseline/pull/33/files), this PR includes a Powershell command that parses the administrator query accurately. With this branch's code the V-73221 test passes with expected results.
